### PR TITLE
feat: 상단 컨트롤 3줄 개편, 필터 초기화 버튼, 오류/빈 상태 배너

### DIFF
--- a/src/app/games/_utils/filters.ts
+++ b/src/app/games/_utils/filters.ts
@@ -118,3 +118,17 @@ export function mergeFilters(base: GameFilters, partial: Partial<GameFilters>): 
 
   return next;
 }
+
+export function resetGameFilters(
+  current: GameFilters,
+  opts: { keepOrdering?: boolean; keepPageSize?: boolean } = {
+    keepOrdering: true,
+    keepPageSize: true,
+  }
+): GameFilters {
+  const next: GameFilters = {};
+  if (opts.keepOrdering && current.ordering) next.ordering = current.ordering;
+  if (opts.keepPageSize && typeof current.page_size === 'number')
+    next.page_size = current.page_size;
+  return next;
+}

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -14,6 +14,8 @@ import { useInfiniteGames } from '@/queries/games';
 import GameGrid from '@/components/GameGrid';
 import { Button } from '@/components/ui/button';
 import FiltersResetButton from '@/components/games/FiltersResetButton';
+import ErrorBanner from '@/components/games/ErrorBanner';
+import EmptyState from '@/components/games/EmptyState';
 import {
   Select,
   SelectTrigger,
@@ -73,18 +75,12 @@ export default function GamesPage() {
   const showInitialLoading = (isPending || (!data && isFetching)) && items.length === 0;
   if (showInitialLoading) return <div className="p-6">로딩 중…</div>;
 
-  if (isError) {
-    const e = error as any;
-    return (
-      <div className="p-6 text-red-600">
-        에러: {e?.message || '알 수 없는 에러'}
-        {'status' in e && e?.status ? ` (HTTP ${e.status})` : null}
-      </div>
-    );
-  }
-
   const orderingValue = filters.ordering ?? 'popularity';
   const isBackgroundUpdating = isFetching && !isFetchingNextPage && items.length > 0;
+  const isEmpty = !isPending && !isFetching && !isError && items.length === 0;
+
+  const errorMessage = (error as any)?.message as string | undefined;
+  const errorStatus = (error as any)?.status ? `HTTP ${(error as any).status}` : undefined;
 
   return (
     <div className="space-y-4 p-6">
@@ -146,15 +142,18 @@ export default function GamesPage() {
         </div>
       </div>
 
-      {items.length === 0 ? (
-        <div>결과가 없어요.</div>
+      {isError && (
+        <ErrorBanner message={errorMessage} statusText={errorStatus} onRetry={() => refetch()} />
+      )}
+
+      {isEmpty ? (
+        <EmptyState onReset={handleResetFilters} />
       ) : (
         <>
           <div className="mb-4 text-sm text-gray-500">{items.length}개 표시</div>
           <div className="space-y-6">
             <GameGrid games={items} />
           </div>
-
           {hasNextPage && (
             <Button onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
               {isFetchingNextPage ? '로딩…' : '더 보기'}

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -8,10 +8,12 @@ import {
   mergeFilters,
   GameFilters,
   Ordering,
+  resetGameFilters,
 } from './_utils/filters';
 import { useInfiniteGames } from '@/queries/games';
 import GameGrid from '@/components/GameGrid';
 import { Button } from '@/components/ui/button';
+import FiltersResetButton from '@/components/games/FiltersResetButton';
 import {
   Select,
   SelectTrigger,
@@ -59,6 +61,13 @@ export default function GamesPage() {
     });
   };
 
+  const handleResetFilters = useCallback(() => {
+    const next = resetGameFilters(filters, { keepOrdering: true, keepPageSize: true });
+    const sp = stringifyGameFilters(next);
+    const qs = sp.toString();
+    router.replace(qs ? `/games?${qs}` : '/games');
+  }, [filters, router]);
+
   const items = useMemo(() => data?.pages.flatMap((p: any) => p.results) ?? [], [data]);
 
   const showInitialLoading = (isPending || (!data && isFetching)) && items.length === 0;
@@ -79,33 +88,62 @@ export default function GamesPage() {
 
   return (
     <div className="space-y-4 p-6">
-      <div className="flex flex-wrap items-center gap-2">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="grid gap-3">
+        <div role="group" aria-labelledby="search-controls" className="flex items-center gap-2">
+          <h2 id="search-controls" className="sr-only">
+            검색
+          </h2>
           <SearchBar placeholder="게임 검색 (Enter)" className="max-w-md" />
         </div>
-        <FiltersPanel filters={filters} onChange={updateFilters} />
-        <Select value={orderingValue} onValueChange={onChangeOrdering}>
-          <SelectTrigger className="w-48">
-            <SelectValue placeholder="정렬" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="popularity">인기순(기본)</SelectItem>
-            <SelectItem value="-rating">평점순</SelectItem>
-            <SelectItem value="-metacritic">메타크리틱순</SelectItem>
-            <SelectItem value="-released">최신 출시순</SelectItem>
-            <SelectItem value="released">오래된 출시순</SelectItem>
-          </SelectContent>
-        </Select>
 
-        <Button
-          onClick={() => refetch()}
-          disabled={isFetching && !isFetchingNextPage}
-          aria-live="polite"
+        <div
+          role="group"
+          aria-labelledby="filter-controls"
+          className="flex flex-wrap items-center gap-2"
         >
-          {isFetching && !isFetchingNextPage ? '업데이트 중…' : '최신 가져오기'}
-        </Button>
+          <h2 id="filter-controls" className="sr-only">
+            필터
+          </h2>
+          <FiltersPanel filters={filters} onChange={updateFilters} />
+          <FiltersResetButton onReset={handleResetFilters} />
+        </div>
 
-        {isBackgroundUpdating && <span className="ml-2 text-sm text-gray-500">업데이트 중…</span>}
+        <div
+          role="group"
+          aria-labelledby="sort-controls"
+          className="flex flex-wrap items-center gap-2"
+        >
+          <h2 id="sort-controls" className="sr-only">
+            정렬 및 새로고침
+          </h2>
+          <Select value={orderingValue} onValueChange={onChangeOrdering}>
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="정렬" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="popularity">인기순(기본)</SelectItem>
+              <SelectItem value="-rating">평점순</SelectItem>
+              <SelectItem value="-metacritic">메타크리틱순</SelectItem>
+              <SelectItem value="-released">최신 출시순</SelectItem>
+              <SelectItem value="released">오래된 출시순</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Button
+            onClick={() => refetch()}
+            disabled={isFetching && !isFetchingNextPage}
+            aria-live="polite"
+            className="shrink-0"
+          >
+            {isFetching && !isFetchingNextPage ? '업데이트 중…' : '최신 가져오기'}
+          </Button>
+
+          {isBackgroundUpdating && (
+            <span className="text-sm text-gray-500" aria-live="polite">
+              업데이트 중…
+            </span>
+          )}
+        </div>
       </div>
 
       {items.length === 0 ? (

--- a/src/components/games/EmptyState.tsx
+++ b/src/components/games/EmptyState.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+type Props = {
+  onReset?: () => void;
+  className?: string;
+};
+
+export default function EmptyState({ onReset, className }: Props) {
+  return (
+    <div
+      className={[
+        'flex flex-col items-center justify-center rounded-xl border border-gray-200 px-6 py-12 text-center',
+        className ?? '',
+      ].join(' ')}
+    >
+      <h3 className="text-base font-semibold text-gray-900">조건에 맞는 게임이 없습니다</h3>
+      <p className="mt-1 text-sm text-gray-600">필터를 변경하거나 초기화해 다시 시도해 보세요.</p>
+      {onReset && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-4"
+          onClick={onReset}
+          aria-label="필터 초기화"
+          title="필터 초기화"
+        >
+          필터 초기화
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/games/ErrorBanner.tsx
+++ b/src/components/games/ErrorBanner.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+type Props = {
+  message?: string;
+  statusText?: string;
+  onRetry?: () => void;
+  className?: string;
+};
+
+export default function ErrorBanner({ message, statusText, onRetry, className }: Props) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={[
+        'rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900',
+        className ?? '',
+      ].join(' ')}
+    >
+      <div className="font-medium">불러오는 중 문제가 발생했어요.</div>
+      <div className="mt-1">
+        {message ?? '알 수 없는 오류'}
+        {statusText ? ` (${statusText})` : ''}
+      </div>
+      {onRetry && (
+        <div className="mt-2">
+          <Button variant="outline" size="sm" onClick={onRetry} aria-label="다시 시도">
+            다시 시도
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/games/FiltersResetButton.tsx
+++ b/src/components/games/FiltersResetButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+type Props = {
+  onReset: () => void;
+  className?: string;
+};
+
+export default function FiltersResetButton({ onReset, className }: Props) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className={className}
+      onClick={onReset}
+      aria-label="필터 초기화"
+      title="필터 초기화"
+    >
+      필터 초기화
+    </Button>
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용
- 상단 컨트롤을 **3줄 레이아웃**으로 개편: ① 검색 ② 장르/플랫폼+리셋 ③ 정렬+최신가져오기
- **필터 초기화 버튼** 추가(shadcn `Button`): `search/genres/platforms` 초기화, `ordering/page_size` 유지
- **오류 배너(ErrorBanner)** 도입: `role="alert"`, “다시 시도” 버튼 연결
- **빈 상태(EmptyState)** 도입: 결과 0건 시 카드 표기, “필터 초기화” 연결
- **접근성 보강**: 섹션별 `role="group"`+`sr-only` 제목, 주요 버튼 `aria-label`
- URL 단일 소스 규칙 유지: 모든 조작은 `router.replace(stringifyGameFilters(...))`로 동기화

## 🔍 변경 이유
- 동일 크기 컨트롤이 한 줄에 모여 **인지 부하가 높아** 섹션별로 **시각적 그룹**을 분명히 하기 위함
- 실패/무결과 상황에서 **즉시 피드백**과 **복구 경로(다시 시도/초기화)** 제공 → 탐색 회복력 향상
- 프로젝트 전반의 **URL = 단일 소스** 계약 유지 + 접근성(a11y) 베이스라인 강화

## 🧪 테스트 방법
1. **레이아웃 확인**
   - `/games` 접속 → 상단 컨트롤이 3줄(검색 / 필터+리셋 / 정렬+최신)로 보이는지
   - 키보드 포커스 이동 시 섹션이 자연스럽고 스크린리더가 그룹 제목을 읽는지(`role="group"`, `sr-only`)
2. **필터 초기화 버튼**
   - 검색어 입력 + 장르/플랫폼 다중 선택 → **필터 초기화** 클릭
   - URL 쿼리에서 `search/genres/platforms` 제거, `ordering/page_size` 유지, 리스트 초기화
3. **오류 배너(ErrorBanner)**
   - API키 변경 후 재실행 → `(HTTP 401/403)` 상태 표시 확인
4. **빈 상태(EmptyState)**
   - 존재하기 어려운 검색어(`zzqwxxyy!!??`) 입력
   - 빈 상태 카드 노출, 카드의 **필터 초기화** 클릭 시 목록 복구
5. **정렬/최신 가져오기**
   - 정렬을 `-rating` 등으로 변경 → 리스트 정렬 변경 확인
   - **최신 가져오기** 클릭 → 백그라운드 업데이트 문구(“업데이트 중…”) 노출 후 해제
6. **무한 스크롤/더 보기**
   - `더 보기` 클릭 시 다음 페이지 로드 및 버튼 상태(“로딩…”) 전환 확인

## 📷 스크린샷 (선택)

<img width="1420" height="722" alt="image" src="https://github.com/user-attachments/assets/53d4b0dc-98f2-41c9-8d8b-2bad0a8fb3d7" />

<img width="1420" height="722" alt="image" src="https://github.com/user-attachments/assets/0c14ab00-b6eb-4f12-abe5-5d55f1a9c75e" />

