### PR TITLE
feat: MultiSelect에 검색 인풋 추가

### DIFF
--- a/src/components/games/MultiSelect.tsx
+++ b/src/components/games/MultiSelect.tsx
@@ -16,6 +16,7 @@ interface MultiSelectProps {
   onChange?: (next: Array<string | number>) => void;
   placeholder?: string;
   ariaLabel?: string;
+  searchPlaceholder?: string;
 }
 
 export default function MultiSelect({
@@ -25,8 +26,10 @@ export default function MultiSelect({
   onChange,
   placeholder = '전체',
   ariaLabel,
+  searchPlaceholder = '옵션 검색…',
 }: MultiSelectProps) {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
 
   const selectedMap = useMemo(() => {
     const m = new Map<string | number, boolean>();
@@ -34,12 +37,21 @@ export default function MultiSelect({
     return m;
   }, [value]);
 
+  const displayedItems = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((it) => it.label.toLowerCase().includes(q));
+  }, [items, query]);
+
   const toggle = (v: string | number) => {
     const next = selectedMap.has(v) ? value.filter((x) => x !== v) : [...value, v];
     onChange?.(next);
   };
 
-  const clearAll = () => onChange?.([]);
+  const clearAll = () => {
+    onChange?.([]);
+    setQuery('');
+  };
 
   return (
     <div className="flex items-center gap-2">
@@ -50,7 +62,7 @@ export default function MultiSelect({
             aria-label={ariaLabel ?? label}
             aria-haspopup="listbox"
             aria-expanded={open}
-            className="justify-between min-w-[180px]"
+            className="min-w-[180px] justify-between"
           >
             <span className="truncate">
               {value.length ? `${label}: ${value.length}개 선택` : `${label}: ${placeholder}`}
@@ -67,9 +79,55 @@ export default function MultiSelect({
                 variant="ghost"
                 onClick={clearAll}
                 aria-label={`${label} 선택 초기화`}
+                title={`${label} 선택 초기화`}
               >
                 <X className="h-4 w-4" />
               </Button>
+            )}
+          </div>
+
+          <div className="mb-2 px-1">
+            <div className="relative">
+              <input
+                className="w-full rounded-md border px-2 py-1 pr-8 text-sm outline-none focus:ring-2 focus:ring-gray-300"
+                placeholder={searchPlaceholder}
+                aria-label="옵션 검색"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                aria-label="검색어 지우기"
+                title="검색어 지우기"
+                className={[
+                  'absolute right-2 top-1/2 -translate-y-1/2 rounded p-1',
+                  'transition-opacity',
+                  query ? 'opacity-100' : 'opacity-0 pointer-events-none',
+                ].join(' ')}
+              >
+                <X className="h-4 w-4 text-gray-500" />
+              </button>
+            </div>
+          </div>
+
+          <div className="mb-2 flex items-center justify-between px-1 text-xs text-gray-600">
+            <span>
+              표시: {displayedItems.length} / 전체 {items.length}
+            </span>
+            {value.length > 0 && (
+              <button
+                type="button"
+                className="rounded-md border px-2 py-0.5 hover:bg-gray-50"
+                onClick={clearAll}
+                aria-label="선택 해제"
+                title="선택 해제"
+              >
+                선택 해제
+              </button>
             )}
           </div>
 
@@ -80,28 +138,40 @@ export default function MultiSelect({
               aria-multiselectable="true"
               className="flex flex-col gap-1"
             >
-              {items.map((it) => {
-                const checked = selectedMap.has(it.value);
-                return (
-                  <li key={String(it.value)} role="option" aria-selected={checked}>
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => toggle(it.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          toggle(it.value);
-                        }
-                      }}
-                      className="w-full cursor-pointer select-none rounded-lg px-2 py-1.5 hover:bg-muted flex items-center gap-2"
-                    >
-                      <Checkbox checked={checked} onCheckedChange={() => toggle(it.value)} />
-                      <span className="text-sm">{it.label}</span>
-                    </div>
-                  </li>
-                );
-              })}
+              {displayedItems.length === 0 ? (
+                <li className="px-2 py-6 text-center text-sm text-muted-foreground">
+                  결과가 없습니다
+                </li>
+              ) : (
+                displayedItems.map((it) => {
+                  const checked = selectedMap.has(it.value);
+                  return (
+                    <li key={String(it.value)} role="option" aria-selected={checked}>
+                      <div
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => toggle(it.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            toggle(it.value);
+                          }
+                        }}
+                        className="flex w-full cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300"
+                        aria-label={it.label}
+                        title={it.label}
+                      >
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={() => toggle(it.value)}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                        <span className="text-sm">{it.label}</span>
+                      </div>
+                    </li>
+                  );
+                })
+              )}
             </ul>
           </ScrollArea>
         </PopoverContent>


### PR DESCRIPTION
## 📌 작업 내용
- MultiSelect 팝오버 상단에 **검색 인풋** 추가(로컬 필터, 대소문자 무시)
- 표시 개수 안내 및 **선택 해제** 버튼 추가
- "지우기" 텍스트 버튼 → **X 아이콘** 절대배치로 교체(레이아웃 점프 제거)
- FiltersPanel에 **searchPlaceholder** 전달 및 옵션 메모이즈(useMemo) 적용

## 🔍 변경 이유
- 장르/플랫폼 옵션이 많은 경우 빠르게 좁히기 위해 내부 검색 제공
- Clear 버튼으로 인해 입력 라인 높이가 변하면서 **요소 점프**가 발생하던 문제 해결

## 🧪 테스트 방법

<!-- 로컬에서 어떻게 확인했는지 -->
1. `/games` → 장르/플랫폼 MultiSelect 열기
2. 검색어 입력 시 리스트가 **실시간 필터링**되는지 확인
3. 검색 인풋 포커스 상태에서 **Enter/Space**를 눌러도 항목 토글이 일어나지 않는지(전파 차단)
4. X 아이콘 클릭 시 검색어가 지워지고 리스트가 원상 복구되는지(레이아웃 흔들림 없음)
5. **선택 해제** 클릭 시 선택값이 모두 초기화되는지
6. 항목 클릭/Enter/Space로 선택/해제 정상 동작
7. URL 동기화(장르=slug CSV, 플랫폼=id CSV) 기존과 동일하게 동작하는지 확인

## 📷 스크린샷 (선택)

<img width="1420" height="722" alt="image" src="https://github.com/user-attachments/assets/d32092f9-d9c3-4812-9403-04f5581a8263" />

