### PR TITLE
feat: 상세 페이지 스캐폴딩 추가(/games/[id]) 및 서비스/훅 도입, 상세 이동 연결

### DIFF
--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import Image from 'next/image';
+import { useMemo } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { useGame } from '@/app/games/_hooks/useGame';
+import ErrorBanner from '@/components/games/ErrorBanner';
+
+export default function GameDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const gameId = useMemo(() => Number(params?.id), [params?.id]);
+  const { data, isPending, isError, error, refetch } = useGame(gameId);
+
+  if (!Number.isFinite(gameId)) {
+    return (
+      <div className="p-6">
+        잘못된 접근입니다.{' '}
+        <Button variant="outline" className="ml-2" onClick={() => router.push('/games')}>
+          목록으로
+        </Button>
+      </div>
+    );
+  }
+
+  if (isPending && !data) {
+    return <div className="p-6">로딩 중…</div>;
+  }
+
+  if (isError) {
+    const e = error as any;
+    return (
+      <div className="p-6 space-y-3">
+        <ErrorBanner
+          message={e?.message ?? '알 수 없는 오류'}
+          statusText={e?.status ? `HTTP ${e.status}` : undefined}
+          onRetry={() => refetch()}
+        />
+        <Button variant="outline" onClick={() => router.push('/games')} aria-label="목록으로">
+          목록으로
+        </Button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const {
+    name,
+    background_image,
+    released,
+    rating,
+    metacritic,
+    description_raw,
+    genres,
+    platforms,
+  } = data;
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 space-y-6">
+      {/* 상단 헤더 */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        {/* 썸네일 */}
+        <div className="relative aspect-video w-full overflow-hidden rounded-xl border sm:w-[360px]">
+          {background_image ? (
+            <Image
+              src={background_image}
+              alt={`${name} 배경 이미지`}
+              fill
+              className="object-cover"
+              sizes="(max-width: 640px) 100vw, 360px"
+              priority
+            />
+          ) : (
+            <div className="grid h-full place-items-center text-sm text-muted-foreground">
+              이미지 없음
+            </div>
+          )}
+        </div>
+
+        {/* 메타 정보 */}
+        <div className="flex-1 space-y-3">
+          <h1 className="text-2xl font-semibold leading-tight">{name}</h1>
+          <div className="text-sm text-muted-foreground flex flex-wrap gap-2">
+            {released ? <span>발매: {released}</span> : null}
+            {typeof rating === 'number' ? <span>평점: {rating.toFixed(1)}</span> : null}
+            {typeof metacritic === 'number' ? <span>메타크리틱: {metacritic}</span> : null}
+          </div>
+
+          <div className="flex flex-wrap gap-2 pt-1">
+            {(genres ?? []).map((g) => (
+              <span key={g.id} className="rounded-full border px-2 py-0.5 text-xs">
+                {g.name}
+              </span>
+            ))}
+            {(platforms ?? []).map((p) => (
+              <span key={p.platform.id} className="rounded-full border px-2 py-0.5 text-xs">
+                {p.platform.name}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <Button variant="outline" onClick={() => router.push('/games')} aria-label="목록으로">
+              목록으로
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {description_raw ? (
+        <section aria-labelledby="desc-title" className="prose dark:prose-invert max-w-none">
+          <h2 id="desc-title" className="sr-only">
+            설명
+          </h2>
+          <p className="whitespace-pre-wrap leading-relaxed">{description_raw}</p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/games/_hooks/useGame.ts
+++ b/src/app/games/_hooks/useGame.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { games } from '@/services/rawg/games';
+import { GameDetails } from '@/types/rawg';
+
+export function useGame(id: number) {
+  return useQuery<GameDetails>({
+    queryKey: ['rawg', 'game', id],
+    queryFn: () => games.detail(id),
+    placeholderData: keepPreviousData,
+    staleTime: Infinity,
+    gcTime: 30 * 60 * 1000,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchInterval: false,
+    enabled: Number.isFinite(id),
+  });
+}

--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -1,10 +1,25 @@
+'use client';
+
+import Link from 'next/link';
+import type { GameSummary } from '@/types/rawg';
 import GameCard from './GameCard';
 
-export default function GameGrid({ games }: { games: any[] }) {
+type Props = {
+  games: GameSummary[];
+};
+
+export default function GameGrid({ games }: Props) {
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4">
       {games.map((g) => (
-        <GameCard key={g.id} game={g} />
+        <Link
+          key={g.id}
+          href={`/games/${g.id}`}
+          aria-label={`${g.name} 상세 보기`}
+          className="group block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+        >
+          <GameCard game={g} />
+        </Link>
       ))}
     </div>
   );

--- a/src/services/rawg/games.ts
+++ b/src/services/rawg/games.ts
@@ -1,6 +1,7 @@
 import rawgClient from '@/lib/api/rawgClient';
 import type { Params } from '@/lib/api/rawgClient';
-import type { GamesListResponse, GameSummary } from '@/types/rawg';
+import type { GamesListResponse } from '@/types/rawg';
+import type { GameDetails } from '@/types/rawg';
 import type { GameFilters, Ordering } from '@/app/games/_utils/filters';
 
 export interface GamesListParams {
@@ -55,9 +56,12 @@ export const games = {
     }),
 
   detail: (id: number | string, opts?: { signal?: AbortSignal; timeoutMs?: number }) =>
-    rawgClient.get<GameSummary & { description_raw?: string }>(
+    rawgClient.get<GameDetails>(
       `games/${id}`,
       {},
-      { signal: opts?.signal, timeoutMs: opts?.timeoutMs }
+      {
+        signal: opts?.signal,
+        timeoutMs: opts?.timeoutMs,
+      }
     ),
 };

--- a/src/types/rawg.ts
+++ b/src/types/rawg.ts
@@ -27,3 +27,16 @@ export interface Platform {
   name: string;
   slug: string;
 }
+
+export interface GameDetails {
+  id: number;
+  name: string;
+  description_raw?: string;
+  background_image?: string | null;
+  released?: string | null;
+  rating?: number | null;
+  metacritic?: number | null;
+  genres?: Genre[];
+  platforms?: { platform: Platform }[];
+  website?: string | null;
+}


### PR DESCRIPTION
## 📌 작업 내용
- 상세 페이지 `/games/[id]` 골격 추가(서비스/훅/타입 포함)
- GameGrid 카드 클릭 시 상세 페이지로 이동(Link 래핑)
- ErrorBanner 재사용(로딩/오류 처리)

## 🔍 변경 이유
- 상세 페이지가 있어도 진입 경로가 없어 가시성이 낮았음 → 카드에서 바로 접근 가능하도록 연결

## 🧪 테스트 방법
1) `/games`에서 카드 클릭 → `/games/[id]`로 이동 확인
2) `/games/3498` 직접 접근 → 제목/메타/이미지/설명 표시

## 📷 스크린샷 (선택)

<img width="1266" height="722" alt="image" src="https://github.com/user-attachments/assets/27e91bd1-c298-4de5-a7d7-ff2a0370de1c" />
