### PR TITLE
feat: games 상세페이지 접기/더보기 및 목록으로 돌아갈 시 필터 유지

### DIFF
--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useMemo, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useGame } from '@/app/games/_hooks/useGame';
 import ErrorBanner from '@/components/games/ErrorBanner';
@@ -10,6 +10,9 @@ import ErrorBanner from '@/components/games/ErrorBanner';
 export default function GameDetailPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const rawFrom = searchParams?.get('from') ?? '';
+  const backTo = rawFrom.startsWith('/games') ? rawFrom : '/games';
 
   const gameId = useMemo(() => Number(params?.id), [params?.id]);
   const { data, isPending, isError, error, refetch } = useGame(gameId);
@@ -61,7 +64,7 @@ export default function GameDetailPage() {
     return (
       <div className="p-6">
         잘못된 접근입니다.{` `}
-        <Button variant="outline" className="ml-2" onClick={() => router.push('/games')}>
+        <Button variant="outline" className="ml-2" onClick={() => router.push(backTo)}>
           목록으로
         </Button>
       </div>
@@ -81,7 +84,7 @@ export default function GameDetailPage() {
           statusText={e?.status ? `HTTP ${e.status}` : undefined}
           onRetry={() => refetch()}
         />
-        <Button variant="outline" onClick={() => router.push('/games')} aria-label="목록으로">
+        <Button variant="outline" onClick={() => router.push(backTo)} aria-label="목록으로">
           목록으로
         </Button>
       </div>
@@ -134,7 +137,7 @@ export default function GameDetailPage() {
           </div>
 
           <div className="flex gap-2 pt-2">
-            <Button variant="outline" onClick={() => router.push('/games')} aria-label="목록으로">
+            <Button variant="outline" onClick={() => router.push(backTo)} aria-label="목록으로">
               목록으로
             </Button>
           </div>

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { useGame } from '@/app/games/_hooks/useGame';
@@ -14,10 +14,53 @@ export default function GameDetailPage() {
   const gameId = useMemo(() => Number(params?.id), [params?.id]);
   const { data, isPending, isError, error, refetch } = useGame(gameId);
 
+  const [expanded, setExpanded] = useState(false);
+  const descriptionRaw = data?.description_raw ?? '';
+  const paragraphs = useMemo(
+    () =>
+      descriptionRaw
+        .split(/\r?\n\s*\r?\n/)
+        .map((p) => p.trim())
+        .filter(Boolean),
+    [descriptionRaw]
+  );
+  const totalChars = useMemo(() => descriptionRaw.length, [descriptionRaw]);
+
+  const MIN_TOTAL_TO_CLAMP = 600;
+  const MIN_EXCERPT_CHARS = 280;
+  const LONG_PARA_CHARS = 800;
+  const MAX_EXCERPT_PARAS = 2;
+  const MIN_TOTAL_TO_TOGGLE = 1400;
+  const MIN_HIDDEN_CHARS = 500;
+  const MIN_HIDDEN_RATIO = 0.38;
+
+  const previewParas = useMemo(() => {
+    if (totalChars < MIN_TOTAL_TO_CLAMP) return paragraphs;
+    if (paragraphs.length === 0) return [];
+    const first = paragraphs[0];
+    if (first.length >= MIN_EXCERPT_CHARS) return [first];
+    if (paragraphs.length > 1)
+      return paragraphs.slice(0, Math.min(MAX_EXCERPT_PARAS, paragraphs.length));
+    return [first];
+  }, [paragraphs, totalChars]);
+
+  const previewChars = useMemo(() => previewParas.join('\n\n').length, [previewParas]);
+  const hiddenChars = Math.max(0, totalChars - previewChars);
+  const hiddenRatio = totalChars ? hiddenChars / totalChars : 0;
+  const canToggle =
+    totalChars >= MIN_TOTAL_TO_TOGGLE &&
+    (hiddenChars >= MIN_HIDDEN_CHARS ||
+      hiddenRatio >= MIN_HIDDEN_RATIO ||
+      (previewParas.length === 1 && previewParas[0].length > LONG_PARA_CHARS));
+  const showToggle = canToggle;
+
+  const needsHeightClamp =
+    canToggle && !expanded && previewParas.length === 1 && previewParas[0].length > LONG_PARA_CHARS;
+
   if (!Number.isFinite(gameId)) {
     return (
       <div className="p-6">
-        잘못된 접근입니다.{' '}
+        잘못된 접근입니다.{` `}
         <Button variant="outline" className="ml-2" onClick={() => router.push('/games')}>
           목록으로
         </Button>
@@ -47,22 +90,11 @@ export default function GameDetailPage() {
 
   if (!data) return null;
 
-  const {
-    name,
-    background_image,
-    released,
-    rating,
-    metacritic,
-    description_raw,
-    genres,
-    platforms,
-  } = data;
+  const { name, background_image, released, rating, metacritic, genres, platforms } = data;
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-6">
-      {/* 상단 헤더 */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-        {/* 썸네일 */}
         <div className="relative aspect-video w-full overflow-hidden rounded-xl border sm:w-[360px]">
           {background_image ? (
             <Image
@@ -80,7 +112,6 @@ export default function GameDetailPage() {
           )}
         </div>
 
-        {/* 메타 정보 */}
         <div className="flex-1 space-y-3">
           <h1 className="text-2xl font-semibold leading-tight">{name}</h1>
           <div className="text-sm text-muted-foreground flex flex-wrap gap-2">
@@ -110,12 +141,44 @@ export default function GameDetailPage() {
         </div>
       </div>
 
-      {description_raw ? (
-        <section aria-labelledby="desc-title" className="prose dark:prose-invert max-w-none">
+      {descriptionRaw ? (
+        <section aria-labelledby="desc-title" className="max-w-none">
           <h2 id="desc-title" className="sr-only">
             설명
           </h2>
-          <p className="whitespace-pre-wrap leading-relaxed">{description_raw}</p>
+
+          <div
+            id="desc-content"
+            className="prose dark:prose-invert leading-relaxed"
+            aria-live="polite"
+          >
+            {(expanded || !canToggle ? paragraphs : previewParas).map((p, i) => (
+              <p
+                key={i}
+                className={
+                  needsHeightClamp && i === 0
+                    ? 'relative max-h-[16rem] overflow-hidden whitespace-pre-wrap after:pointer-events-none after:absolute after:bottom-0 after:left-0 after:h-16 after:w-full after:bg-gradient-to-t after:from-background after:to-transparent'
+                    : 'whitespace-pre-wrap'
+                }
+              >
+                {p}
+              </p>
+            ))}
+          </div>
+
+          {showToggle && (
+            <div className="mt-3">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setExpanded((v) => !v)}
+                aria-expanded={expanded}
+                aria-controls="desc-content"
+              >
+                {expanded ? '접기' : '더보기'}
+              </Button>
+            </div>
+          )}
         </section>
       ) : null}
     </div>

--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import type { GameSummary } from '@/types/rawg';
 import GameCard from './GameCard';
 
@@ -9,12 +10,16 @@ type Props = {
 };
 
 export default function GameGrid({ games }: Props) {
+  const sp = useSearchParams();
+  const qs = sp?.toString() ?? '';
+  const returnTo = qs ? `/games?${qs}` : '/games';
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-4">
       {games.map((g) => (
         <Link
           key={g.id}
-          href={`/games/${g.id}`}
+          href={{ pathname: `/games/${g.id}`, query: { from: returnTo } }}
           aria-label={`${g.name} 상세 보기`}
           className="group block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
         >


### PR DESCRIPTION
## 📌 작업 내용
- 상세 설명 **더보기/접기 v2** 도입 (문단+길이 하이브리드, 대칭 토글)
  - 짧은 본문(총 글자수 < 600)은 **토글 없이 전체 노출**
  - 기본: **첫 문단**(너무 짧으면 최대 **2문단**)만 미리보기
  - **긴 단일 문단**은 접힘에서만 **높이 클램프(그라데이션)**
  - **대칭 토글**: 콘텐츠 기반(canToggle)으로만 버튼 노출 → 더보기 있으면 접기도 항상 존재
- 상세의 **‘목록으로(필터 유지)’** 구현
  - `GameGrid` → 현재 `/games?...` URL을 **from** 파라미터로 상세에 전달
  - 상세 페이지는 **from**이 `/games`로 시작할 때만 신뢰해 **정확히 원래 목록 URL로 복귀**, 없거나 비정상이면 `/games` 폴백
- 접근성 보강: 토글 버튼에 `aria-expanded`, `aria-controls` 적용

## 🔍 변경 이유
- 긴 설명에서 가독성이 떨어지고, 짧은 본문에도 “더보기”가 떠 **UX 노이즈**가 있었음
- 리스트 → 상세 → 목록 복귀 시 **필터/검색/정렬 상태가 초기화**되어 사용 흐름이 끊겼음
- URL=**단일 소스** 원칙에 맞춰 상태를 보존하고, **일관된 토글 규칙(대칭)**으로 사용 경험을 개선

## 🧪 테스트 방법
1. **짧은 본문(600자 미만)** 상세 진입 → 토글 **없음**, 전체 노출 확인
2. **보통 길이(≥600자, <1400자, 2문단 이상)** → 기본 1문단(짧으면 2문단) + “더보기” 노출 → 클릭 시 전체 노출, 버튼 라벨 **접기**로 유지(대칭)
3. **긴 단일 문단(>800자)** → 접힘에서 **그라데이션 클램프** 보임 → “더보기” → 전체 노출(클램프 제거)
4. **목록 → 상세 → 목록으로**: 검색어/장르/플랫폼/정렬 적용 후 카드 클릭 → 상세 상단 “목록으로” → **원래의 `/games?...`로 복귀**(필터/검색/정렬 유지)
5. **쿼리 없음/직접 진입**(`/games/[id]` 주소창) → “목록으로” → `/games`로 폴백
6. **에러/잘못된 접근 화면**의 “목록으로”도 동일 규칙(backTo)으로 복귀
7. **접근성**: 토글 버튼 `aria-expanded` 상태 변화, `aria-controls="desc-content"` 연결 확인. 키보드로 토글 가능

## 📷 스크린샷 (선택)
<img width="1266" height="919" alt="image" src="https://github.com/user-attachments/assets/7b0b1ac6-25ba-4c2d-b02c-e06bb207a6b8" />
<img width="1266" height="919" alt="image" src="https://github.com/user-attachments/assets/6ff9135e-de71-4731-8561-806a3958d6be" />

