### PR TITLE
feat: 상세페이지 스크린샷 섹션 추가

### DIFF
--- a/src/services/rawg/games.ts
+++ b/src/services/rawg/games.ts
@@ -1,7 +1,6 @@
 import rawgClient from '@/lib/api/rawgClient';
 import type { Params } from '@/lib/api/rawgClient';
-import type { GamesListResponse } from '@/types/rawg';
-import type { GameDetails } from '@/types/rawg';
+import type { GamesListResponse, GameDetails, GameScreenshotsResponse } from '@/types/rawg';
 import type { GameFilters, Ordering } from '@/app/games/_utils/filters';
 
 export interface GamesListParams {
@@ -58,6 +57,16 @@ export const games = {
   detail: (id: number | string, opts?: { signal?: AbortSignal; timeoutMs?: number }) =>
     rawgClient.get<GameDetails>(
       `games/${id}`,
+      {},
+      {
+        signal: opts?.signal,
+        timeoutMs: opts?.timeoutMs,
+      }
+    ),
+
+  screenshots: (id: number | string, opts?: { signal?: AbortSignal; timeoutMs?: number }) =>
+    rawgClient.get<GameScreenshotsResponse>(
+      `games/${id}/screenshots`,
       {},
       {
         signal: opts?.signal,

--- a/src/types/rawg.ts
+++ b/src/types/rawg.ts
@@ -40,3 +40,12 @@ export interface GameDetails {
   platforms?: { platform: Platform }[];
   website?: string | null;
 }
+
+export interface Screenshot {
+  id: number;
+  image: string;
+  width?: number | null;
+  height?: number | null;
+  is_deleted?: boolean;
+}
+export type GameScreenshotsResponse = RawgListResponse<Screenshot>;


### PR DESCRIPTION
## 📌 작업 내용
- 상세 페이지에 **스크린샷 섹션** 추가(가로 스크롤 갤러리)

## 🔍 변경 이유
- 상세에서 즉시 시각적 정보를 제공해 이해도/흥미를 높이기 위함
- 이미지가 없으면 섹션 미노출로 UI 노이즈 최소화

## 📷 스크린샷 (선택)
<img width="1266" height="919" alt="image" src="https://github.com/user-attachments/assets/24208d03-0b8b-4cbf-b252-c582cdfc207f" />
